### PR TITLE
Add support for vouchers

### DIFF
--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -68,7 +68,7 @@ func (h *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			webError(w, fmt.Errorf("could not parse voucher: %w", err), http.StatusBadRequest)
 			return
 		}
-
+		fmt.Printf("Parsed voucher: %+v\n", v)
 		total, received := h.nitroRpcClient.ReceiveVoucher(v)
 
 		// TODO: The received value can be nil if we receive a stale voucher.
@@ -76,6 +76,7 @@ func (h *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			webError(w, fmt.Errorf("stale voucher received with amount %d, we already have a voucher with amount %d", v.Amount.Uint64(), total), http.StatusPaymentRequired)
 			return
 		}
+		fmt.Printf("Payment received from voucher %d\n", received.Uint64())
 
 		if received.Cmp(big.NewInt(expectedPayment)) < 0 {
 			webError(w, fmt.Errorf("payment of %d required, the voucher only resulted in a payment of %d", expectedPayment, received.Uint64()), http.StatusPaymentRequired)

--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -59,7 +59,7 @@ func (h *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if h.nitroRpcClient != nil {
 		// This the payment we expect to receive for the file.
-		const expectedPayment = int64(100)
+		const expectedPayment = int64(5)
 
 		params, _ := url.ParseQuery(r.URL.RawQuery)
 

--- a/cmd/booster-http/gateway_handler.go
+++ b/cmd/booster-http/gateway_handler.go
@@ -69,11 +69,11 @@ func (h *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		fmt.Printf("Parsed voucher: %+v\n", v)
-		total, received := h.nitroRpcClient.ReceiveVoucher(v)
+		_, received := h.nitroRpcClient.ReceiveVoucher(v)
 
-		// TODO: The received value can be nil if we receive a stale voucher.
+		// TODO: A nil value indicates an error with the voucher. We should update to the latest go-nitro which properly returns the error.
 		if received == nil {
-			webError(w, fmt.Errorf("stale voucher received with amount %d, we already have a voucher with amount %d", v.Amount.Uint64(), total), http.StatusPaymentRequired)
+			webError(w, fmt.Errorf("invalid voucher received %+v", v), http.StatusBadRequest)
 			return
 		}
 		fmt.Printf("Payment received from voucher %d\n", received.Uint64())

--- a/cmd/booster-http/server.go
+++ b/cmd/booster-http/server.go
@@ -6,15 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/NYTimes/gziphandler"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/fatih/color"
 	"github.com/filecoin-project/boost-gfm/piecestore"
 	"github.com/filecoin-project/boost-gfm/retrievalmarket"
@@ -30,7 +27,6 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	nrpc "github.com/statechannels/go-nitro/rpc"
-	"github.com/statechannels/go-nitro/types"
 	"go.opencensus.io/stats"
 )
 
@@ -188,29 +184,6 @@ func (s *HttpServer) handleByPieceCid(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.nitroRpcClient != nil {
-		params, _ := url.ParseQuery(r.URL.RawQuery)
-		if !params.Has("channelId") {
-			writeError(w, r, http.StatusPaymentRequired, "a valid channel id must be provided")
-			return
-		}
-		rawChId := params.Get("channelId")
-		chId := types.Destination(common.HexToHash(rawChId))
-
-		// TODO: Allow this to be configurable
-		expectedPaymentAmount := big.NewInt(10)
-
-		hasPaid, err := checkPaymentChannelBalance(s.nitroRpcClient, chId, expectedPaymentAmount)
-		if err != nil {
-			writeError(w, r, http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		if !hasPaid {
-			writeError(w, r, http.StatusPaymentRequired, fmt.Sprintf("payment of %d required", expectedPaymentAmount.Uint64()))
-			return
-		}
-	}
 	// Get a reader over the piece
 	content, err := s.getPieceContent(ctx, pieceCid)
 	if err != nil {

--- a/cmd/booster-http/util.go
+++ b/cmd/booster-http/util.go
@@ -2,12 +2,7 @@ package main
 
 import (
 	"fmt"
-	"errors"
-	"math/big"
 	"net/http"
-
-	"github.com/statechannels/go-nitro/rpc"
-	"github.com/statechannels/go-nitro/types"
 )
 
 func addCommas(count uint64) string {
@@ -16,15 +11,6 @@ func addCommas(count uint64) string {
 		str = str[:i] + "," + str[i:]
 	}
 	return str
-}
-
-// checkPaymentChannelBalance checks a payment channel balance and returns true if the AmountPaid is greater than the expected amount
-func checkPaymentChannelBalance(rpcClient *rpc.RpcClient, paymentChannelId types.Destination, expectedAmount *big.Int) (bool, error) {
-	if rpcClient == nil {
-		return false, errors.New("the rpcClient is nil")
-	}
-	payCh := rpcClient.GetVirtualChannel(paymentChannelId)
-	return (payCh.Balance.PaidSoFar.ToInt().Cmp(expectedAmount) > 0), nil
 }
 
 type corsHandler struct {

--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -10,4 +10,4 @@ echo $MINER_API_INFO
 echo $BOOST_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --serve-files=true --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing
+exec booster-http run --serve-files=true --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing --nitro-enabled --nitro-endpoint=host.docker.internal:4007/api/v1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ replace github.com/libp2p/go-libp2p v0.27.0 => github.com/libp2p/go-libp2p v0.26
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
-	github.com/BurntSushi/toml v1.2.1
+	github.com/BurntSushi/toml v1.3.2
 	github.com/alecthomas/jsonschema v0.0.0-20200530073317-71f438968921
 	github.com/benbjohnson/clock v1.3.5
 	github.com/buger/goterm v1.0.3
@@ -346,7 +346,7 @@ require (
 	github.com/ipfs/boxo v0.10.1
 	github.com/ipfs/kubo v0.21.0-rc1
 	github.com/ipni/go-libipni v0.0.8
-	github.com/statechannels/go-nitro v0.0.0-20230621200904-bfeff118bbbb
+	github.com/statechannels/go-nitro v0.0.0-20230705221739-f11101193ac4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
-github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/clickhouse-go v1.5.4/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
@@ -1846,8 +1846,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
-github.com/statechannels/go-nitro v0.0.0-20230621200904-bfeff118bbbb h1:VqWNBCX02+X2+3i3Q/J5zaRq2UYwkSyq+DflG+df5gE=
-github.com/statechannels/go-nitro v0.0.0-20230621200904-bfeff118bbbb/go.mod h1:XE3dHtihquV0Thj6O8W0WvNWKdtNmUypPNDyVEHc4mk=
+github.com/statechannels/go-nitro v0.0.0-20230705221739-f11101193ac4 h1:4lFtN2eJT7Gs0ouEDTZi9vDbU2T5MoQm0wcYP9IIDeQ=
+github.com/statechannels/go-nitro v0.0.0-20230705221739-f11101193ac4/go.mod h1:jOuma3zrgCVSByahmABHL733LykH8XFqcRv7Ra1ucvM=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=


### PR DESCRIPTION
This updates our forked version of `boost` to the latest `go-nitro` and support vouchers being embedded in the GET requests. booster-http now parses a voucher from the query params in a get request. This voucher is passed into the go-nitro RPC node which validates it and returns the amount of new funds provided by that voucher.  Based on that 
booster-http either serves the request or rejects it with a 402 (if voucher is invalid or the payment amount insufficient).

I've also removed the piece endpoint integration as we're not actively using it and its simpler to just have one point of integration. If we change our minds it should be trivial to add back.

Note that the current implementation means booster-http is "greedy".  It will consume submitted vouchers even if it responds with a 402 for insufficient payment.  For example if booster-http requires a payment of 5 to serve a file and it receives a voucher that would result in a payment of 4, it will still add the voucher to it's go-nitro even though it doesn't serve a file. This is because `booster-http` just passes the voucher into `go-nitro` and that will always add the voucher to the voucher manager. 



