### PR TITLE
Update to go-nitro with support for errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 	github.com/ipfs/boxo v0.10.1
 	github.com/ipfs/kubo v0.21.0-rc1
 	github.com/ipni/go-libipni v0.0.8
-	github.com/statechannels/go-nitro v0.0.0-20230705221739-f11101193ac4
+	github.com/statechannels/go-nitro v0.0.0-20230710223658-280d0225a9d8
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1846,8 +1846,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
-github.com/statechannels/go-nitro v0.0.0-20230705221739-f11101193ac4 h1:4lFtN2eJT7Gs0ouEDTZi9vDbU2T5MoQm0wcYP9IIDeQ=
-github.com/statechannels/go-nitro v0.0.0-20230705221739-f11101193ac4/go.mod h1:jOuma3zrgCVSByahmABHL733LykH8XFqcRv7Ra1ucvM=
+github.com/statechannels/go-nitro v0.0.0-20230710223658-280d0225a9d8 h1:XvtnSc99gOVH5Cd5b4OKU0Zx+YdA7am1QmZPCNkXZNw=
+github.com/statechannels/go-nitro v0.0.0-20230710223658-280d0225a9d8/go.mod h1:h2DTAAg1B2CgyL4y3YWIHwcLQk0ZqMHzOCfUXLBURTI=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=


### PR DESCRIPTION
Fixes #18 

Updates to the latest version of `go-nitro` with an rpc client that now returns an error. 