### PR TITLE
Disable some docker containers for performance

### DIFF
--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -87,29 +87,29 @@ services:
       - ./data/lotus:/var/lib/lotus:ro
       - ./data/lotus-miner:/var/lib/lotus-miner:ro
     labels:
-      - "com.docker-tc.enabled=1"
-      - "com.docker-tc.delay=10ms"
+      - "com.docker-tc.enabled=0"
+ 
 
-  booster-bitswap:
-    container_name: booster-bitswap
-    image: ${BOOSTER_BITSWAP_IMAGE}
-    ports:
-      - "8888:8888"
-    environment:
-      - BOOSTER_BITSWAP_REPO=/var/lib/booster-bitswap
-      - BOOST_PATH=/var/lib/boost
-      - LOTUS_PATH=/var/lib/lotus
-      - LOTUS_MINER_PATH=/var/lib/lotus-miner
-    restart: unless-stopped
-    logging: *default-logging
-    volumes:
-      - ./data/booster-bitswap:/var/lib/booster-bitswap:rw
-      - ./data/boost:/var/lib/boost:ro
-      - ./data/lotus:/var/lib/lotus:ro
-      - ./data/lotus-miner:/var/lib/lotus-miner:ro
-    labels:
-      - "com.docker-tc.enabled=1"
-      - "com.docker-tc.delay=10ms"
+  # booster-bitswap:
+  #   container_name: booster-bitswap
+  #   image: ${BOOSTER_BITSWAP_IMAGE}
+  #   ports:
+  #     - "8888:8888"
+  #   environment:
+  #     - BOOSTER_BITSWAP_REPO=/var/lib/booster-bitswap
+  #     - BOOST_PATH=/var/lib/boost
+  #     - LOTUS_PATH=/var/lib/lotus
+  #     - LOTUS_MINER_PATH=/var/lib/lotus-miner
+  #   restart: unless-stopped
+  #   logging: *default-logging
+  #   volumes:
+  #     - ./data/booster-bitswap:/var/lib/booster-bitswap:rw
+  #     - ./data/boost:/var/lib/boost:ro
+  #     - ./data/lotus:/var/lib/lotus:ro
+  #     - ./data/lotus-miner:/var/lib/lotus-miner:ro
+  #   labels:
+  #     - "com.docker-tc.enabled=1"
+  #     - "com.docker-tc.delay=10ms"
 
   demo-http-server:
     container_name: demo-http-server
@@ -123,19 +123,19 @@ services:
       - "com.docker-tc.limit=1mbps"
       - "com.docker-tc.delay=100ms"
 
-  tc:
-    image: "${DOCKER_IMAGE_TERMINAL:-lukaszlach/docker-tc}"
-    container_name: docker-tc
-    cap_add:
-      - NET_ADMIN
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /var/docker-tc:/var/docker-tc
-    deploy:
-      mode: global
-      restart_policy:
-        condition: any
-    environment:
-      HTTP_BIND: "${HTTP_BIND:-127.0.0.1}"
-      HTTP_PORT: "${HTTP_PORT:-4080}"
-    network_mode: host
+  # tc:
+  #   image: "${DOCKER_IMAGE_TERMINAL:-lukaszlach/docker-tc}"
+  #   container_name: docker-tc
+  #   cap_add:
+  #     - NET_ADMIN
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #     - /var/docker-tc:/var/docker-tc
+  #   deploy:
+  #     mode: global
+  #     restart_policy:
+  #       condition: any
+  #   environment:
+  #     HTTP_BIND: "${HTTP_BIND:-127.0.0.1}"
+  #     HTTP_PORT: "${HTTP_PORT:-4080}"
+  #   network_mode: host


### PR DESCRIPTION
This disables some of the docker containers that we don't need for `booster-http` and the demo. I'm using this locally to prevent docker from eating up all my RAM and/or freezing.