### PR TITLE
Use free resource tiers for circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
   golang:
     docker:
       - image: cimg/go:1.19.7
-    resource_class: 2xlarge
+    resource_class: large
   ubuntu:
     docker:
       - image: ubuntu:20.04
@@ -266,7 +266,7 @@ workflows:
   ci:
     jobs:
       - lint-all:
-          concurrency: "16"   # expend all docker 2xlarge CPUs.
+          concurrency: "4"   # expend all docker large CPUs.
       - mod-tidy-check
       - gofmt
       - cbor-check


### PR DESCRIPTION
This gets the boost repo CI running by switching the use of `2xlarge` machines (which require money) to `large` which is free.

It looks like the `test-all` job seems to fail, but different tests seem to fail on different runs. I suspect that there are some race conditions/flicker/timeout being exacerbated by the slower circleci machine. Looking at filecoin's CI I see there was a [failure that had to be re-run ](https://app.circleci.com/pipelines/github/filecoin-project/boost/4547) at the commit we're currently based off of. Locally I'm able to get all the test passing eventually but I do see occasional failures that I have to rerun.


For now this at least gets the linting and formatting CI jobs running. Hopefully upgrading to a paid plan and using the `2xlarge` will get test-all passing.