### PR TITLE
Enable nitro payment integration using an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,15 @@ make devnet/down
 
 rm -rf ~/.cache/filecoin-proof-parameters
 ```
+### Nitro payment integration
+
+To enable nitro payment integration for `booster-http` the `BOOSTER_HTTP_NITRO_ENABLED` env var must be set. The env var `BOOSTER_HTTP_NITRO_ENDPOINT` can also be set to specify a specific nitro RPC endpoint; if its not set a default endpoint of `host.docker.internal:4007/api/v1` is used.
+
+```bash
+docker stop m booster-http
+docker rm booster-http
+BOOSTER_HTTP_NITRO_ENABLED=true BOOSTER_HTTP_NITRO_ENDPOINT=someurl:4007/api/v1  docker compose -f ./docker/devnet/docker-compose.yaml up -d
+```
 
 ## License
 

--- a/docker/devnet/booster-http/entrypoint.sh
+++ b/docker/devnet/booster-http/entrypoint.sh
@@ -10,4 +10,5 @@ echo $MINER_API_INFO
 echo $BOOST_API_INFO
 
 echo Starting booster-http...
-exec booster-http run --serve-files=true --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO --tracing --nitro-enabled --nitro-endpoint=host.docker.internal:4007/api/v1
+exec booster-http run --serve-files=true --api-boost=$BOOST_API_INFO --api-fullnode=$FULLNODE_API_INFO --api-storage=$MINER_API_INFO  --tracing \
+ --nitro-enabled=$BOOSTER_HTTP_NITRO_ENABLED --nitro-endpoint=$BOOSTER_HTTP_NITRO_ENDPOINT

--- a/docker/devnet/docker-compose.yaml
+++ b/docker/devnet/docker-compose.yaml
@@ -80,6 +80,8 @@ services:
       - BOOST_PATH=/var/lib/boost
       - LOTUS_PATH=/var/lib/lotus
       - LOTUS_MINER_PATH=/var/lib/lotus-miner
+      - BOOSTER_HTTP_NITRO_ENABLED=${BOOSTER_HTTP_NITRO_ENABLED:-false}
+      - BOOSTER_HTTP_NITRO_ENDPOINT=${BOOSTER_HTTP_NITRO_ENDPOINT:-host.docker.internal:4007/api/v1}
     restart: unless-stopped
     logging: *default-logging
     volumes:


### PR DESCRIPTION
Fixes #25 

Currently in our `nitro-integration` branch we modify the [entrypoint for booster-http to always enable nitro ](https://github.com/statechannels/boost/blob/546cf77ff545c01ab67de1d9494f68b9ff869c5e/docker/devnet/booster-http/entrypoint.sh#L13). This means our branch basically requires a nitro rpc server setup if you're running the dockerized booster http, which is not very pratical.

This PR updates the docker compose so the env var `BOOSTER_HTTP_NITRO_ENABLED` can be used to enable the nitro integration. The default behavior, if that env var is not set, is to assume no nitro integration. I've also added `BOOSTER_HTTP_NITRO_ENDPOINT`, which defaults to `host.docker.internal:4007/api/v1`. This can be used if there's a different endpoint we want to use for some reason.
 

With these changes we now need to set `BOOSTER_HTTP_NITRO_ENABLED` when triggering docker compose if we want to enable the nitro payment integration.  To do so you just need to set `BOOSTER_HTTP_NITRO_ENABLED=true` when calling compose. IE:
```
BOOSTER_HTTP_NITRO_ENABLED=true make devnet/up
BOOSTER_HTTP_NITRO_ENABLED=true docker compose -f ./docker/devnet/docker-compose.yaml up -d
```

 
 