### PR TITLE
Get CircleCI working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
   golang:
     docker:
       - image: cimg/go:1.19.7
-    resource_class: 2xlarge
+    resource_class: xlarge
   ubuntu:
     docker:
       - image: ubuntu:20.04
@@ -266,7 +266,7 @@ workflows:
   ci:
     jobs:
       - lint-all:
-          concurrency: "16"   # expend all docker 2xlarge CPUs.
+          concurrency: "8"   # expend all docker 2xlarge CPUs.
       - mod-tidy-check
       - gofmt
       - cbor-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ workflows:
   ci:
     jobs:
       - lint-all:
-          concurrency: "8"   # expend all docker 2xlarge CPUs.
+          concurrency: "8"   # expend all docker xlarge CPUs.
       - mod-tidy-check
       - gofmt
       - cbor-check


### PR DESCRIPTION
Now that we have paid `performance` circleci plan we have access to `xlarge`. Unfortunately we don't have access to `2xlarge` that filecoin uses as that's on more expensive plan. I've made a support request to get access to `2xlarge` but for now this PR just downgrades the resource class to `xlarge`.

This seems to work better than the `large` resource class from the free plan, as the `test-all` job can pass, it can just take a few retries to get it to do so.